### PR TITLE
add link to a calendar

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 
 * Categorical methods have a long history in automata and language theory, but only in recent years a coherent theory has started to emerge. Among them, there are now monadic, coalgebraic, functorial, fibrational and profinite approaches to automata. The purpose of this working group is to discuss these approaches, the connections between them, and their applications to questions in automata and language theory.
 
-* We meet every two weeks on **Tuesday** at **10:30** at [IRIF](https://www.irif.fr/), bâtiment Sophie Germain, pl. Aurélie Nemours, 75013 Paris, France ([map](https://goo.gl/maps/GNZ7y45a9uqDWzea9)). See below for the precise room. 
+* We meet every two weeks on **Tuesday** at **10:30** at [IRIF](https://www.irif.fr/), bâtiment Sophie Germain, pl. Aurélie Nemours, 75013 Paris, France ([map](https://goo.gl/maps/GNZ7y45a9uqDWzea9)). See below for the precise room. A calendar of the sessions can be found [here](https://cloud.irif.fr/remote.php/dav/public-calendars/ADSGntbwqxbDANYM?export).
 
 * To receive email announcements about future meetings, you can subscribe to our [mailing list](https://sympa.lix.polytechnique.fr/lists/info/autcat).
 


### PR DESCRIPTION
I created an online calendar to keep track of the session (it could have helped last year). I'll try to keep it up to date, but I can also give people from IRIF edit rights (I gave them to @samvang and @daniela-petrisan already).